### PR TITLE
[codex] Fix batch status row clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Initial ADRs 已補上，用來記錄第一版 MVS 的基礎架構決策：
   Single UI restore behavior、Single restore processing status transition、
   Single/Batch animated processing indicator behavior、
   readable Single/Batch status output、Batch UI progress/status behavior、
+  unclipped Batch per-file status row labels、
   Single image inspection behavior、output naming、Batch restore runner orchestration、
   before/after compare view interaction、Single preview stale tooltip regression、
   1024x1024 first-drag rendering smoke check、

--- a/README.md
+++ b/README.md
@@ -118,16 +118,18 @@ Windows build target：
 - Python 3.12.8 64-bit
 - PowerShell
 - Standard `pip install` flow
+- Source code 可用 GitHub ZIP download；公司環境不需要 `git`
 
 完整建置與打包步驟記錄在
 `docs/windows-build-and-package.md`。
 
 預期 package flow：
 
-1. Developer 在 Windows machine clone/download 此 repository。
+1. Developer 在 Windows machine 下載 GitHub source ZIP，或在可用時 clone 此 repository。
 2. Developer 確認 `assets\icons\denoiser_icon.ico` 存在。
 3. Developer 使用 Python 3.12.8 建立 `.venv`。
-4. Developer 使用標準 `pip install` commands 安裝 dependencies。
+4. Developer 使用逐一 `pip install` commands 安裝 dependencies，方便定位公司網路或
+   package install failure。
 5. Developer 執行 `.\scripts\build_windows.ps1`。
 6. Build script 產生 folder-style release，內含帶有 app icon 的 `Denoiser.exe`、
    dependencies、licenses、bundled model files、bundled icon asset。

--- a/docs/windows-build-and-package.md
+++ b/docs/windows-build-and-package.md
@@ -24,7 +24,7 @@ FA engineer 只需要收到整個 `dist\Denoiser` folder，不需要安裝 Pytho
 - Python 3.12.8 64-bit。
 - PowerShell。
 - Internet connection，用於安裝 build dependencies。
-- Fresh checkout of this repository。
+- Source code from GitHub ZIP download, or a fresh `git clone` if `git` is available.
 - App icon exists at `assets\icons\denoiser_icon.ico`。
 
 確認 Python version：
@@ -39,9 +39,36 @@ Expected:
 Python 3.12.8
 ```
 
-## Clean Checkout
+## Get Source Code
 
-Clone repository：
+### Company Environment Without Git
+
+如果公司電腦不能使用 `git`，請用 GitHub 網頁下載 source ZIP：
+
+1. 開啟 `https://github.com/LesterCtw/Denoiser`。
+2. 點 `Code`。
+3. 點 `Download ZIP`。
+4. 解壓縮 ZIP。
+5. 進入解壓縮後的資料夾，例如 `Denoiser-main`。
+
+PowerShell example：
+
+```powershell
+cd path\to\Denoiser-main
+```
+
+GitHub ZIP 不會包含 `.git` folder，所以 `git status`、`git log` 這類 commands 不會
+運作。這是正常狀況，不是 build failure。
+
+請記錄 ZIP 來源，方便之後追蹤版本：
+
+- GitHub branch 或 PR。
+- ZIP filename。
+- Download date。
+
+### Optional Git Clone
+
+如果你的環境可以使用 `git`，也可以 clone repository：
 
 ```powershell
 git clone https://github.com/LesterCtw/Denoiser.git
@@ -56,7 +83,9 @@ git status --short
 
 Expected: no output.
 
-The clean source checkout should not contain local-only folders such as:
+ZIP workflow 沒有 `.git` metadata，請跳過這個 `git status` check。
+
+The clean source folder should not contain local-only folders such as:
 
 - `.venv`
 - `build`
@@ -66,7 +95,7 @@ The clean source checkout should not contain local-only folders such as:
 - `node_modules`
 - `.pytest_cache`
 
-The clean source checkout should contain the app icon:
+The clean source folder should contain the app icon:
 
 ```powershell
 Test-Path .\assets\icons\denoiser_icon.ico
@@ -94,13 +123,42 @@ Expected:
 Python 3.12.8
 ```
 
-Install dependencies:
+Upgrade `pip`:
 
 ```powershell
 python -m pip install --upgrade pip
+```
+
+Install top-level dependencies one by one:
+
+```powershell
+python -m pip install "numpy>=1.26"
+python -m pip install "onnxruntime>=1.21"
+python -m pip install "Pillow>=10"
+python -m pip install "PySide6>=6.7"
+python -m pip install "rosettasciio>=0.13"
+python -m pip install "tifffile>=2024.8.10"
+python -m pip install "pyinstaller>=6.10"
+python -m pip install "pytest>=8"
+python -m pip install -e . --no-deps
+```
+
+為什麼逐一安裝：
+
+- 如果公司網路或 proxy 導致安裝失敗，可以直接知道是哪個 package 失敗。
+- `requirements.txt` 仍保留作為 dependency reference 和批次安裝 fallback。
+- `python -m pip install -e . --no-deps` 會安裝本地 Denoiser package，但不再重複解析
+  dependencies。
+
+如果你想快速批次安裝，也可以使用：
+
+```powershell
 python -m pip install -r requirements.txt
+python -m pip install "pytest>=8"
 python -m pip install -e .
 ```
+
+但如果批次安裝失敗，請回到上面的逐一安裝方式。
 
 ## Run Tests
 
@@ -108,15 +166,14 @@ python -m pip install -e .
 python -m pytest
 ```
 
-Expected:
+Expected: all tests pass.
 
 ```text
-76 passed
+77 passed
 ```
 
-The exact runtime may vary by machine. The important result is that all tests pass.
-The exact test count may change as coverage grows. If it differs, confirm that every
-test passed.
+The exact runtime and test count may vary as coverage grows. The important result is
+that every test passed and there are no failures or errors.
 
 ## Build the Windows App
 

--- a/docs/windows-release-verification.md
+++ b/docs/windows-release-verification.md
@@ -22,9 +22,25 @@ supported image，並取得預期 output；end user 不需要安裝 Python、`uv
 - Windows 10 或 Windows 11。
 - Python 3.12.8 64-bit。
 - 可連網安裝 build dependencies。
-- 此 repository 的 fresh checkout 或下載副本。
+- 此 repository 的 GitHub ZIP 下載副本；如果環境允許，也可以使用 fresh `git clone`。
 
 完整 build/package commands 請見 `docs/windows-build-and-package.md`。
+
+## Source ZIP Check
+
+如果公司環境不能使用 `git`：
+
+1. 從 GitHub 網頁下載 source ZIP。
+2. 解壓縮後進入資料夾，例如 `Denoiser-main`。
+3. 記錄 ZIP filename、download date、GitHub branch 或 PR。
+
+Pass criteria：
+
+- Source folder 包含 `pyproject.toml`、`requirements.txt`、`scripts\build_windows.ps1`。
+- Source folder 包含 `assets\icons\denoiser_icon.ico`。
+- Source folder 包含 `models`、`licenses`、`src`、`docs`。
+- Source folder 沒有舊的 local build artifacts，例如 `.venv`、`build`、`dist`、`release`。
+- 如果沒有 `.git` folder，這是 ZIP workflow 的正常狀況。
 
 ## Build Steps
 
@@ -34,11 +50,24 @@ supported image，並取得預期 output；end user 不需要安裝 Python、`uv
 cd path\to\Denoiser
 py -3.12 -m venv .venv
 .\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install "numpy>=1.26"
+python -m pip install "onnxruntime>=1.21"
+python -m pip install "Pillow>=10"
+python -m pip install "PySide6>=6.7"
+python -m pip install "rosettasciio>=0.13"
+python -m pip install "tifffile>=2024.8.10"
+python -m pip install "pyinstaller>=6.10"
+python -m pip install "pytest>=8"
+python -m pip install -e . --no-deps
+python -m pytest
 .\scripts\build_windows.ps1
 ```
 
 預期結果：
 
+- Dependency install 每一步都完成；如果失敗，可以知道是哪個 package 失敗。
+- `python -m pytest` 全部通過。
 - `dist\Denoiser\Denoiser.exe` 存在。
 - Script 完成且沒有 errors。
 - Build script 使用 `assets\icons\denoiser_icon.ico` 作為 `Denoiser.exe` icon。
@@ -129,11 +158,15 @@ Pass criteria：
 - Tester:
 - Windows version:
 - Build machine Python version:
-- Commit:
+- Source type: GitHub ZIP / git clone
+- Source version: commit / branch / PR / ZIP filename / download date
 - Release folder path:
 
 ### Results
 
+- Source ZIP/folder contains required project files: pass/fail
+- Individual dependency installs completed: pass/fail
+- `python -m pytest` passed: pass/fail
 - Build script created `Denoiser.exe`: pass/fail
 - App icon appears on `Denoiser.exe` and app window: pass/fail
 - Runtime dependencies included: pass/fail

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -14,8 +14,14 @@ if (-not (Test-Path $iconPath)) {
 }
 
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
-python -m pip install -e .
+python -m pip install "numpy>=1.26"
+python -m pip install "onnxruntime>=1.21"
+python -m pip install "Pillow>=10"
+python -m pip install "PySide6>=6.7"
+python -m pip install "rosettasciio>=0.13"
+python -m pip install "tifffile>=2024.8.10"
+python -m pip install "pyinstaller>=6.10"
+python -m pip install -e . --no-deps
 
 python -m PyInstaller `
   --noconfirm `

--- a/src/denoiser/ui/main_window.py
+++ b/src/denoiser/ui/main_window.py
@@ -481,9 +481,9 @@ class MainWindow(QMainWindow):
             status_kind=file_result.status,
             detail=_readable_batch_detail(file_result.status, detail),
         )
-        item.setSizeHint(row.sizeHint())
         self._batch_list.addItem(item)
         self._batch_list.setItemWidget(item, row)
+        item.setSizeHint(row.sizeHint())
 
     def _update_batch_progress(self, completed_count: int, total_count: int) -> None:
         self._set_batch_progress(f"{completed_count} of {total_count} files")

--- a/tests/test_batch_ui.py
+++ b/tests/test_batch_ui.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import QApplication, QLabel, QListWidget
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from denoiser.models import DenoiseMode
+from denoiser.workflow import BatchFileResult, BatchFileStatus
 from denoiser.ui.compare_view import CompareView
 from denoiser.ui.main_window import MainWindow
 
@@ -134,19 +135,28 @@ def test_batch_ui_can_cancel_remaining_files_between_restores(tmp_path: Path) ->
     assert not window.cancel_batch_button.isVisible()
 
 
-def test_batch_ui_status_badge_is_not_clipped(tmp_path: Path) -> None:
+def test_batch_ui_status_row_labels_are_not_clipped(tmp_path: Path) -> None:
     app = QApplication.instance() or QApplication([])
-    source = tmp_path / "unsupported notes with a long filename.json"
-    source.write_text("skip me")
 
     window = MainWindow(engine=object())
     window.resize(1280, 800)
     window.show()
     window.show_batch_mode()
-    window.set_batch_folder_path(tmp_path)
-
-    window.start_batch_button.click()
-    process_events_until(app, lambda: window.status_text().startswith("Batch complete:"))
+    window._append_batch_file_result(
+        BatchFileResult(
+            source_path=tmp_path / "launch_phase4_overlay_uat.py",
+            status=BatchFileStatus.SKIPPED,
+            message="Unsupported file format: .py",
+        )
+    )
+    window._append_batch_file_result(
+        BatchFileResult(
+            source_path=tmp_path / "phase4_bad_slice_stack 1.json",
+            status=BatchFileStatus.SKIPPED,
+            message="Unsupported file format: .json",
+        )
+    )
+    app.processEvents()
 
     batch_list = window.findChild(QListWidget, "BatchList")
     assert batch_list is not None
@@ -154,5 +164,8 @@ def test_batch_ui_status_badge_is_not_clipped(tmp_path: Path) -> None:
     first_row = batch_list.itemWidget(first_item)
     assert first_row is not None
     badge = first_row.findChild(QLabel, "BatchStatusSkipped")
+    detail = first_row.findChild(QLabel, "BatchFileDetail")
     assert badge is not None
+    assert detail is not None
     assert badge.geometry().height() >= badge.sizeHint().height()
+    assert detail.geometry().height() >= detail.minimumSizeHint().height()


### PR DESCRIPTION
## Summary

Fixes the Batch mode per-file status row layout so the `Unsupported format ...` detail text is not clipped.

## Root Cause

The `QListWidgetItem` size hint was measured before the row widget was installed into the list. After Qt stylesheet polishing, the actual row needed more height than the item had reserved, so the detail label could be compressed.

## Changes

- Measure and set the row item size hint after `setItemWidget` applies the real styled widget sizing.
- Extend the Batch UI regression test to assert both the status badge and detail label have enough height.
- Update `README.md` to reflect the new test coverage.

## Validation

- `uv run pytest -q`
- Pre-commit hook: `uv run pytest`