### PR TITLE
[codex] extract UI rendering modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Initial ADRs 已補上，用來記錄第一版 MVS 的基礎架構決策：
   animated processing indicator、success/failure 狀態。
 - Batch mode UI：folder selection、共用 mode buttons、Start Batch、progress、
   animated processing indicator、可捲動的 per-file status list。
+- Batch mode status row rendering 已集中在 dedicated UI module，讓 per-file
+  status label、detail text、badge object names 的規則有單一維護位置。
 - Batch cancellation between files、per-file failure isolation，以及 final
   restored/failed/skipped/cancelled summary counts。
 - Single mode preview：選圖後顯示 raw-only preview；restore 後顯示 raw/restored
@@ -68,7 +70,8 @@ Initial ADRs 已補上，用來記錄第一版 MVS 的基礎架構決策：
   denoised-folder rejection、
   unsupported-input rejection、multi-page TIFF rejection、batch cancellation、
   batch failure isolation、JPEG-to-TIFF output、PNG/TIFF output preservation、
-  RGB/RGBA-to-grayscale conversion、overwrite behavior、uint16 TIFF clipping、
+  Batch result row formatting、RGB/RGBA-to-grayscale conversion、overwrite behavior、
+  uint16 TIFF clipping、
   conservative TIFF/PNG metadata preservation。
 
 尚未實作：
@@ -185,11 +188,14 @@ Denoiser/
       ui/
         __init__.py
         batch_restore_runner.py
+        batch_result_row.py
         compare_view.py
         main_window.py
         restore_task_runner.py
+        theme.py
   tests/
     test_batch_restore_runner.py
+    test_batch_result_row.py
     test_batch_ui.py
     test_batch_workflow.py
     test_app_icon.py

--- a/src/denoiser/ui/batch_result_row.py
+++ b/src/denoiser/ui/batch_result_row.py
@@ -1,0 +1,105 @@
+"""Batch result row rendering for the PySide6 UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout, QWidget
+
+from denoiser.workflow import BatchFileResult, BatchFileStatus
+
+
+@dataclass(frozen=True)
+class BatchResultListEntry:
+    item_text: str
+    row_widget: QWidget
+
+
+def batch_result_list_entry(file_result: BatchFileResult) -> BatchResultListEntry:
+    status = batch_status_label(file_result.status)
+    detail = (
+        _short_path_label(file_result.output_path)
+        if file_result.output_path is not None
+        else file_result.message
+    )
+    return BatchResultListEntry(
+        item_text=f"{file_result.source_path.name} - {status}: {detail}",
+        row_widget=_batch_result_row(
+            filename=file_result.source_path.name,
+            status=status,
+            status_kind=file_result.status,
+            detail=readable_batch_detail(file_result.status, detail),
+        ),
+    )
+
+
+def batch_status_label(status: BatchFileStatus) -> str:
+    if status is BatchFileStatus.RESTORED:
+        return "Restored"
+    if status is BatchFileStatus.FAILED:
+        return "Failed"
+    if status is BatchFileStatus.CANCELLED:
+        return "Cancelled"
+    return "Skipped"
+
+
+def readable_batch_detail(status: BatchFileStatus, detail: str) -> str:
+    if status is BatchFileStatus.RESTORED:
+        return f"Saved to {detail}"
+    if detail.startswith("Unsupported file format:"):
+        return detail.replace("Unsupported file format:", "Unsupported format", 1)
+    if detail.startswith("Multi-page TIFF files are not supported."):
+        return "Multi-page TIFF not supported. Use a single 2D image."
+    return detail
+
+
+def _short_path_label(path: Path) -> str:
+    return f"{path.parent.name}/{path.name}"
+
+
+def _batch_result_row(
+    filename: str,
+    status: str,
+    status_kind: BatchFileStatus,
+    detail: str,
+) -> QWidget:
+    row = QFrame()
+    row.setObjectName("BatchResultItem")
+    layout = QVBoxLayout(row)
+    layout.setContentsMargins(14, 12, 14, 12)
+    layout.setSpacing(8)
+
+    header = QHBoxLayout()
+    header.setContentsMargins(0, 0, 0, 0)
+    header.setSpacing(10)
+
+    filename_label = QLabel(filename)
+    filename_label.setObjectName("BatchFileName")
+    filename_label.setWordWrap(True)
+    header.addWidget(filename_label, 1)
+
+    badge = QLabel(status)
+    badge.setObjectName(_batch_status_badge_name(status_kind))
+    badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    header.addWidget(badge)
+
+    layout.addLayout(header)
+
+    detail_label = QLabel(detail)
+    detail_label.setObjectName("BatchFileDetail")
+    detail_label.setWordWrap(True)
+    layout.addWidget(detail_label)
+
+    return row
+
+
+def _batch_status_badge_name(status: BatchFileStatus) -> str:
+    if status is BatchFileStatus.RESTORED:
+        return "BatchStatusRestored"
+    if status is BatchFileStatus.FAILED:
+        return "BatchStatusFailed"
+    if status is BatchFileStatus.CANCELLED:
+        return "BatchStatusCancelled"
+    return "BatchStatusSkipped"

--- a/src/denoiser/ui/main_window.py
+++ b/src/denoiser/ui/main_window.py
@@ -33,10 +33,11 @@ from denoiser.models import (
 )
 from denoiser.single_image_inspection import inspect_single_image
 from denoiser.ui.batch_restore_runner import BatchRestoreRunner
+from denoiser.ui.batch_result_row import batch_result_list_entry
 from denoiser.ui.compare_view import CompareView
 from denoiser.ui.restore_task_runner import RestoreTaskRunner
+from denoiser.ui.theme import main_window_stylesheet
 from denoiser.workflow import (
-    BatchFileStatus,
     BatchRestoreRun,
     RestoreEngine,
     restore_single_image,
@@ -71,7 +72,7 @@ class MainWindow(QMainWindow):
         root_layout.addWidget(self._build_preview_area(), 1)
 
         self.setCentralWidget(root)
-        self.setStyleSheet(_stylesheet())
+        self.setStyleSheet(main_window_stylesheet())
 
     def set_single_image_path(self, path: Path) -> None:
         self._single_image_path = Path(path)
@@ -468,22 +469,11 @@ class MainWindow(QMainWindow):
         self.start_batch_button.show()
 
     def _append_batch_file_result(self, file_result) -> None:
-        status = _batch_status_label(file_result.status)
-        detail = (
-            _short_path_label(file_result.output_path)
-            if file_result.output_path is not None
-            else file_result.message
-        )
-        item = QListWidgetItem(f"{file_result.source_path.name} - {status}: {detail}")
-        row = _batch_result_row(
-            filename=file_result.source_path.name,
-            status=status,
-            status_kind=file_result.status,
-            detail=_readable_batch_detail(file_result.status, detail),
-        )
+        entry = batch_result_list_entry(file_result)
+        item = QListWidgetItem(entry.item_text)
         self._batch_list.addItem(item)
-        self._batch_list.setItemWidget(item, row)
-        item.setSizeHint(row.sizeHint())
+        self._batch_list.setItemWidget(item, entry.row_widget)
+        item.setSizeHint(entry.row_widget.sizeHint())
 
     def _update_batch_progress(self, completed_count: int, total_count: int) -> None:
         self._set_batch_progress(f"{completed_count} of {total_count} files")
@@ -512,262 +502,3 @@ class MainWindow(QMainWindow):
 
     def _set_processing_indicator_visible(self, visible: bool) -> None:
         self._processing_indicator.setVisible(visible)
-
-def _stylesheet() -> str:
-    return """
-    QMainWindow {
-        background: #111214;
-        color: #f2f3f5;
-        font-family: "Segoe UI", "SF Pro Text", Arial, sans-serif;
-        font-size: 14px;
-    }
-
-    #Sidebar {
-        background: #181a1f;
-        border-right: 1px solid #2c3038;
-    }
-
-    #PreviewArea {
-        background: #101114;
-    }
-
-    #Title {
-        color: #f6f7f9;
-        font-size: 28px;
-        font-weight: 600;
-    }
-
-    #SectionLabel {
-        color: #aeb4be;
-        font-size: 12px;
-        font-weight: 600;
-        text-transform: uppercase;
-    }
-
-    #StatusCard {
-        border: 1px solid #303641;
-        border-radius: 8px;
-        background: #12151a;
-    }
-
-    #StatusTitle {
-        color: #f2f4f8;
-        font-size: 15px;
-        font-weight: 650;
-    }
-
-    #StatusDetails {
-        color: #c9d0db;
-        font-size: 13px;
-        font-weight: 500;
-        line-height: 135%;
-    }
-
-    #ProcessingIndicator {
-        min-height: 6px;
-        max-height: 6px;
-        border: none;
-        border-radius: 3px;
-        background: #2c3038;
-    }
-
-    #ProcessingIndicator::chunk {
-        border-radius: 3px;
-        background: #2f80ed;
-    }
-
-    QPushButton {
-        min-height: 36px;
-        padding: 8px 14px;
-        border: 1px solid #3a3f49;
-        border-radius: 8px;
-        background: #23262d;
-        color: #eef1f5;
-    }
-
-    QPushButton:hover {
-        border-color: #596170;
-        background: #2a2e36;
-    }
-
-    QPushButton:checked {
-        border-color: #2f80ed;
-        color: #ffffff;
-        background: #1d3f6e;
-    }
-
-    QPushButton:disabled {
-        border-color: #2b2f36;
-        background: #1b1d22;
-        color: #737b87;
-    }
-
-    #PrimaryButton {
-        border: none;
-        border-radius: 18px;
-        background: #2f80ed;
-        color: #ffffff;
-        font-weight: 600;
-    }
-
-    #PrimaryButton:hover {
-        background: #4a90f3;
-    }
-
-    #PrimaryButton:disabled {
-        background: #24415f;
-        color: #8fa7c5;
-    }
-
-    #CompareView {
-        border: 1px solid #2c3038;
-        border-radius: 8px;
-        background: #15171b;
-        color: #aeb4be;
-    }
-
-    #BatchPanel {
-        background: #15171b;
-    }
-
-    #BatchProgress {
-        color: #f2f3f5;
-        font-size: 20px;
-        font-weight: 600;
-    }
-
-    #BatchList {
-        border: 1px solid #2c3038;
-        border-radius: 8px;
-        background: #111318;
-        color: #e4e7ec;
-        font-size: 15px;
-        padding: 8px;
-    }
-
-    #BatchList::item {
-        border: none;
-        margin: 0 0 8px 0;
-        padding: 0;
-    }
-
-    #BatchResultItem {
-        border: 1px solid #2a303a;
-        border-radius: 8px;
-        background: #151820;
-    }
-
-    #BatchFileName {
-        color: #f1f4f8;
-        font-size: 15px;
-        font-weight: 650;
-    }
-
-    #BatchFileDetail {
-        color: #aeb7c4;
-        font-size: 13px;
-        font-weight: 500;
-    }
-
-    #BatchStatusRestored,
-    #BatchStatusSkipped,
-    #BatchStatusFailed,
-    #BatchStatusCancelled {
-        min-width: 76px;
-        min-height: 24px;
-        padding: 4px 8px;
-        border-radius: 10px;
-        font-size: 12px;
-        font-weight: 650;
-    }
-
-    #BatchStatusRestored {
-        color: #d8f5e3;
-        background: #1d5b38;
-    }
-
-    #BatchStatusSkipped {
-        color: #d8dde6;
-        background: #38404d;
-    }
-
-    #BatchStatusFailed {
-        color: #ffe0e0;
-        background: #743030;
-    }
-
-    #BatchStatusCancelled {
-        color: #ffe8bd;
-        background: #6b4b18;
-    }
-    """
-
-
-def _batch_status_label(status: BatchFileStatus) -> str:
-    if status is BatchFileStatus.RESTORED:
-        return "Restored"
-    if status is BatchFileStatus.FAILED:
-        return "Failed"
-    if status is BatchFileStatus.CANCELLED:
-        return "Cancelled"
-    return "Skipped"
-
-
-def _short_path_label(path: Path) -> str:
-    return f"{path.parent.name}/{path.name}"
-
-
-def _readable_batch_detail(status: BatchFileStatus, detail: str) -> str:
-    if status is BatchFileStatus.RESTORED:
-        return f"Saved to {detail}"
-    if detail.startswith("Unsupported file format:"):
-        return detail.replace("Unsupported file format:", "Unsupported format", 1)
-    if detail.startswith("Multi-page TIFF files are not supported."):
-        return "Multi-page TIFF not supported. Use a single 2D image."
-    return detail
-
-
-def _batch_result_row(
-    filename: str,
-    status: str,
-    status_kind: BatchFileStatus,
-    detail: str,
-) -> QWidget:
-    row = QFrame()
-    row.setObjectName("BatchResultItem")
-    layout = QVBoxLayout(row)
-    layout.setContentsMargins(14, 12, 14, 12)
-    layout.setSpacing(8)
-
-    header = QHBoxLayout()
-    header.setContentsMargins(0, 0, 0, 0)
-    header.setSpacing(10)
-
-    filename_label = QLabel(filename)
-    filename_label.setObjectName("BatchFileName")
-    filename_label.setWordWrap(True)
-    header.addWidget(filename_label, 1)
-
-    badge = QLabel(status)
-    badge.setObjectName(_batch_status_badge_name(status_kind))
-    badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    header.addWidget(badge)
-
-    layout.addLayout(header)
-
-    detail_label = QLabel(detail)
-    detail_label.setObjectName("BatchFileDetail")
-    detail_label.setWordWrap(True)
-    layout.addWidget(detail_label)
-
-    return row
-
-
-def _batch_status_badge_name(status: BatchFileStatus) -> str:
-    if status is BatchFileStatus.RESTORED:
-        return "BatchStatusRestored"
-    if status is BatchFileStatus.FAILED:
-        return "BatchStatusFailed"
-    if status is BatchFileStatus.CANCELLED:
-        return "BatchStatusCancelled"
-    return "BatchStatusSkipped"

--- a/src/denoiser/ui/theme.py
+++ b/src/denoiser/ui/theme.py
@@ -1,0 +1,193 @@
+"""Shared stylesheet for the PySide6 UI."""
+
+from __future__ import annotations
+
+
+def main_window_stylesheet() -> str:
+    return """
+    QMainWindow {
+        background: #111214;
+        color: #f2f3f5;
+        font-family: "Segoe UI", "SF Pro Text", Arial, sans-serif;
+        font-size: 14px;
+    }
+
+    #Sidebar {
+        background: #181a1f;
+        border-right: 1px solid #2c3038;
+    }
+
+    #PreviewArea {
+        background: #101114;
+    }
+
+    #Title {
+        color: #f6f7f9;
+        font-size: 28px;
+        font-weight: 600;
+    }
+
+    #SectionLabel {
+        color: #aeb4be;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+    }
+
+    #StatusCard {
+        border: 1px solid #303641;
+        border-radius: 8px;
+        background: #12151a;
+    }
+
+    #StatusTitle {
+        color: #f2f4f8;
+        font-size: 15px;
+        font-weight: 650;
+    }
+
+    #StatusDetails {
+        color: #c9d0db;
+        font-size: 13px;
+        font-weight: 500;
+        line-height: 135%;
+    }
+
+    #ProcessingIndicator {
+        min-height: 6px;
+        max-height: 6px;
+        border: none;
+        border-radius: 3px;
+        background: #2c3038;
+    }
+
+    #ProcessingIndicator::chunk {
+        border-radius: 3px;
+        background: #2f80ed;
+    }
+
+    QPushButton {
+        min-height: 36px;
+        padding: 8px 14px;
+        border: 1px solid #3a3f49;
+        border-radius: 8px;
+        background: #23262d;
+        color: #eef1f5;
+    }
+
+    QPushButton:hover {
+        border-color: #596170;
+        background: #2a2e36;
+    }
+
+    QPushButton:checked {
+        border-color: #2f80ed;
+        color: #ffffff;
+        background: #1d3f6e;
+    }
+
+    QPushButton:disabled {
+        border-color: #2b2f36;
+        background: #1b1d22;
+        color: #737b87;
+    }
+
+    #PrimaryButton {
+        border: none;
+        border-radius: 18px;
+        background: #2f80ed;
+        color: #ffffff;
+        font-weight: 600;
+    }
+
+    #PrimaryButton:hover {
+        background: #4a90f3;
+    }
+
+    #PrimaryButton:disabled {
+        background: #24415f;
+        color: #8fa7c5;
+    }
+
+    #CompareView {
+        border: 1px solid #2c3038;
+        border-radius: 8px;
+        background: #15171b;
+        color: #aeb4be;
+    }
+
+    #BatchPanel {
+        background: #15171b;
+    }
+
+    #BatchProgress {
+        color: #f2f3f5;
+        font-size: 20px;
+        font-weight: 600;
+    }
+
+    #BatchList {
+        border: 1px solid #2c3038;
+        border-radius: 8px;
+        background: #111318;
+        color: #e4e7ec;
+        font-size: 15px;
+        padding: 8px;
+    }
+
+    #BatchList::item {
+        border: none;
+        margin: 0 0 8px 0;
+        padding: 0;
+    }
+
+    #BatchResultItem {
+        border: 1px solid #2a303a;
+        border-radius: 8px;
+        background: #151820;
+    }
+
+    #BatchFileName {
+        color: #f1f4f8;
+        font-size: 15px;
+        font-weight: 650;
+    }
+
+    #BatchFileDetail {
+        color: #aeb7c4;
+        font-size: 13px;
+        font-weight: 500;
+    }
+
+    #BatchStatusRestored,
+    #BatchStatusSkipped,
+    #BatchStatusFailed,
+    #BatchStatusCancelled {
+        min-width: 76px;
+        min-height: 24px;
+        padding: 4px 8px;
+        border-radius: 10px;
+        font-size: 12px;
+        font-weight: 650;
+    }
+
+    #BatchStatusRestored {
+        color: #d8f5e3;
+        background: #1d5b38;
+    }
+
+    #BatchStatusSkipped {
+        color: #d8dde6;
+        background: #38404d;
+    }
+
+    #BatchStatusFailed {
+        color: #ffe0e0;
+        background: #743030;
+    }
+
+    #BatchStatusCancelled {
+        color: #ffe8bd;
+        background: #6b4b18;
+    }
+    """

--- a/tests/test_batch_result_row.py
+++ b/tests/test_batch_result_row.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from PySide6.QtWidgets import QApplication, QLabel
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from denoiser.ui.batch_result_row import (
+    batch_result_list_entry,
+    readable_batch_detail,
+)
+from denoiser.workflow import BatchFileResult, BatchFileStatus
+
+
+def test_batch_result_list_entry_formats_restored_file(tmp_path: Path) -> None:
+    app = QApplication.instance() or QApplication([])
+    source = tmp_path / "wafer.tif"
+    output = tmp_path / "denoised_HRSEM" / "wafer.tif"
+
+    entry = batch_result_list_entry(
+        BatchFileResult(
+            source_path=source,
+            status=BatchFileStatus.RESTORED,
+            message="Restored",
+            output_path=output,
+        )
+    )
+
+    badge = entry.row_widget.findChild(QLabel, "BatchStatusRestored")
+    detail = entry.row_widget.findChild(QLabel, "BatchFileDetail")
+
+    assert app is not None
+    assert entry.item_text == "wafer.tif - Restored: denoised_HRSEM/wafer.tif"
+    assert badge is not None
+    assert badge.text() == "Restored"
+    assert detail is not None
+    assert detail.text() == "Saved to denoised_HRSEM/wafer.tif"
+
+
+def test_readable_batch_detail_uses_user_friendly_error_messages() -> None:
+    assert (
+        readable_batch_detail(
+            BatchFileStatus.SKIPPED,
+            "Unsupported file format: .py",
+        )
+        == "Unsupported format .py"
+    )
+    assert (
+        readable_batch_detail(
+            BatchFileStatus.SKIPPED,
+            "Multi-page TIFF files are not supported.",
+        )
+        == "Multi-page TIFF not supported. Use a single 2D image."
+    )

--- a/tests/test_ui_theme.py
+++ b/tests/test_ui_theme.py
@@ -9,6 +9,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from denoiser.ui.compare_view import CompareView
 from denoiser.ui.main_window import MainWindow
+from denoiser.ui.theme import main_window_stylesheet
 
 
 def _rendered_average_lightness(widget: QWidget) -> float:
@@ -54,3 +55,11 @@ def test_batch_theme_and_disabled_controls_remain_readable_in_dark_theme() -> No
     assert batch_panel is not None
     assert _rendered_average_lightness(batch_panel) < 75
     assert 25 < _rendered_average_lightness(window.start_batch_button) < 140
+
+
+def test_main_window_stylesheet_contains_batch_result_selectors() -> None:
+    stylesheet = main_window_stylesheet()
+
+    assert "#BatchResultItem" in stylesheet
+    assert "#BatchStatusRestored" in stylesheet
+    assert "#BatchStatusFailed" in stylesheet


### PR DESCRIPTION
## Summary

- Move Batch per-file status row rendering into a dedicated UI module.
- Move the main window stylesheet into a dedicated theme module.
- Add focused tests for Batch result row formatting and theme selectors.
- Update README.md so the source of truth reflects the new UI module layout.

## Why

`MainWindow` was carrying orchestration, Batch status row formatting, and the full stylesheet in one module. Splitting the rendering and theme rules improves locality while keeping the public behavior unchanged.

## Impact

- No product behavior changes are intended.
- Future changes to Batch result rows or theme selectors can be made in smaller modules.
- `MainWindow` stays focused on wiring the UI workflow.

## Validation

- Pre-commit hook ran `prettier --ignore-unknown --write`.
- Pre-commit hook ran `uv run pytest`: 80 passed.