### PR TITLE
[codex] Fix Windows package runtime paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Initial ADRs 已補上，用來記錄第一版 MVS 的基礎架構決策：
 - PySide6 application entry point 和基本 main window。
 - App/window icon asset 已放在 `assets/icons/denoiser_icon.ico`，runtime 和
   Windows build script 會使用同一個 icon。
+- Runtime resource paths 已支援 source tree 和 PyInstaller frozen app；Windows
+  onedir release 中的 bundled `assets`、`models`、`licenses` 會從 `_internal`
+  讀取。
 - 四個必要 ONNX model files 已放在 `models/`。
 - Third-party notices 和 upstream `tk_r_em` GPL license copy。
 - 支援 whole-image 和 patch-based inference 的最小 CPU ONNX inference wrapper。
@@ -135,7 +138,8 @@ Windows build target：
    package install failure。
 5. Developer 執行 `.\scripts\build_windows.ps1`。
 6. Build script 產生 folder-style release，內含帶有 app icon 的 `Denoiser.exe`、
-   dependencies、licenses、bundled model files、bundled icon asset。
+   `_internal` runtime folder、dependencies、licenses、bundled model files、
+   bundled icon asset。
 7. Developer 將 `dist\Denoiser` 壓縮成 release zip。
 8. FA engineers 只收到 release folder 或 zip，並執行 `Denoiser.exe`。
 

--- a/docs/windows-build-and-package.md
+++ b/docs/windows-build-and-package.md
@@ -9,14 +9,19 @@
 ```text
 dist\Denoiser\
   Denoiser.exe
-  ...
-  assets\
-  models\
-  licenses\
+  _internal\
+    ...
+    assets\
+    models\
+    licenses\
 ```
 
 FA engineer 只需要收到整個 `dist\Denoiser` folder，不需要安裝 Python、`uv`、`pip`，
 也不需要 internet connection。
+
+PyInstaller 6 的 onedir build 預設會把 bundled data 和 runtime dependencies 放在
+`_internal`。這是正常 layout，不是 build failure。不要只複製 `Denoiser.exe`；必須保留
+整個 `dist\Denoiser` folder。
 
 ## Build Machine Requirements
 
@@ -169,7 +174,7 @@ python -m pytest
 Expected: all tests pass.
 
 ```text
-77 passed
+85 passed
 ```
 
 The exact runtime and test count may vary as coverage grows. The important result is
@@ -195,13 +200,13 @@ Confirm these files exist:
 
 ```powershell
 Test-Path .\dist\Denoiser\Denoiser.exe
-Test-Path .\dist\Denoiser\assets\icons\denoiser_icon.ico
-Test-Path .\dist\Denoiser\models\sfr_hrstem.onnx
-Test-Path .\dist\Denoiser\models\sfr_lrstem.onnx
-Test-Path .\dist\Denoiser\models\sfr_hrsem.onnx
-Test-Path .\dist\Denoiser\models\sfr_lrsem.onnx
-Test-Path .\dist\Denoiser\licenses\THIRD_PARTY_NOTICES.md
-Test-Path .\dist\Denoiser\licenses\tk_r_em_LICENSE.txt
+Test-Path .\dist\Denoiser\_internal\assets\icons\denoiser_icon.ico
+Test-Path .\dist\Denoiser\_internal\models\sfr_hrstem.onnx
+Test-Path .\dist\Denoiser\_internal\models\sfr_lrstem.onnx
+Test-Path .\dist\Denoiser\_internal\models\sfr_hrsem.onnx
+Test-Path .\dist\Denoiser\_internal\models\sfr_lrsem.onnx
+Test-Path .\dist\Denoiser\_internal\licenses\THIRD_PARTY_NOTICES.md
+Test-Path .\dist\Denoiser\_internal\licenses\tk_r_em_LICENSE.txt
 ```
 
 Each command should print:
@@ -219,8 +224,8 @@ New-Item -ItemType Directory -Force .\release
 Compress-Archive -Path .\dist\Denoiser -DestinationPath .\release\Denoiser-windows-python-3.12.8.zip -Force
 ```
 
-The zip should contain the `Denoiser` folder, including `Denoiser.exe`, app icon asset,
-model files, runtime dependencies, and license notices.
+The zip should contain the `Denoiser` folder, including `Denoiser.exe`, `_internal`,
+app icon asset, model files, runtime dependencies, and license notices.
 
 Do not commit `dist`, `build`, `release`, `.venv`, or generated zip files. They are local
 build artifacts.

--- a/docs/windows-release-verification.md
+++ b/docs/windows-release-verification.md
@@ -79,17 +79,19 @@ python -m pytest
 Pass criteria：
 
 - `Denoiser.exe` 存在。
-- Release folder 包含 PyInstaller 產生的 runtime dependency files。
+- Release folder 包含 `_internal` folder。PyInstaller 6 onedir build 預設會把 runtime
+  dependency files 和 bundled data 放在這裡。
 - Release folder 包含 app icon asset：
-  - `assets\icons\denoiser_icon.ico`
+  - `_internal\assets\icons\denoiser_icon.ico`
 - Release folder 包含以下 model files：
-  - `models\sfr_hrstem.onnx`
-  - `models\sfr_lrstem.onnx`
-  - `models\sfr_hrsem.onnx`
-  - `models\sfr_lrsem.onnx`
+  - `_internal\models\sfr_hrstem.onnx`
+  - `_internal\models\sfr_lrstem.onnx`
+  - `_internal\models\sfr_hrsem.onnx`
+  - `_internal\models\sfr_lrsem.onnx`
 - Release folder 包含 license notices：
-  - `licenses\THIRD_PARTY_NOTICES.md`
-  - `licenses\tk_r_em_LICENSE.txt`
+  - `_internal\licenses\THIRD_PARTY_NOTICES.md`
+  - `_internal\licenses\tk_r_em_LICENSE.txt`
+- 不要只複製 `Denoiser.exe`。End-user launch test 必須使用整個 `dist\Denoiser` folder。
 
 ## End-User Launch Test
 

--- a/src/denoiser/app.py
+++ b/src/denoiser/app.py
@@ -22,3 +22,7 @@ def main() -> int:
     window.show()
 
     return app.exec()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/denoiser/app_icon.py
+++ b/src/denoiser/app_icon.py
@@ -2,24 +2,19 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 from PySide6.QtGui import QIcon
+
+from denoiser.runtime_paths import resource_path
 
 APP_ICON_RELATIVE_PATH = Path("assets/icons/denoiser_icon.ico")
 
 
 def application_icon_path() -> Path | None:
-    bundle_root = getattr(sys, "_MEIPASS", None)
-    candidates = []
-    if bundle_root is not None:
-        candidates.append(Path(bundle_root) / APP_ICON_RELATIVE_PATH)
-    candidates.append(Path(__file__).resolve().parents[2] / APP_ICON_RELATIVE_PATH)
-
-    for candidate in candidates:
-        if candidate.is_file():
-            return candidate
+    candidate = resource_path(APP_ICON_RELATIVE_PATH)
+    if candidate.is_file():
+        return candidate
     return None
 
 

--- a/src/denoiser/engine.py
+++ b/src/denoiser/engine.py
@@ -48,9 +48,9 @@ class OnnxDenoiser:
         settings: InferenceSettings | None = None,
     ) -> None:
         if models_dir is None:
-            from denoiser.models import MODELS_DIR
+            from denoiser.models import default_models_dir
 
-            models_dir = MODELS_DIR
+            models_dir = default_models_dir()
 
         self._models_dir = Path(models_dir)
         self._session_factory = session_factory or _OrtSession

--- a/src/denoiser/models.py
+++ b/src/denoiser/models.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from denoiser.runtime_paths import resource_path
 
-MODELS_DIR = Path(__file__).resolve().parents[2] / "models"
+MODELS_DIR = resource_path("models")
 
 
 class DenoiseMode(str, Enum):
@@ -77,11 +78,17 @@ def output_folder_for_mode(mode: DenoiseMode) -> str:
     return _MODEL_BY_MODE[mode].output_folder
 
 
-def model_path_for(mode: DenoiseMode, models_dir: Path = MODELS_DIR) -> Path:
+def default_models_dir() -> Path:
+    return resource_path("models")
+
+
+def model_path_for(mode: DenoiseMode, models_dir: Path | None = None) -> Path:
+    if models_dir is None:
+        models_dir = default_models_dir()
     return models_dir / f"{model_tag_for(mode)}.onnx"
 
 
-def missing_model_paths(models_dir: Path = MODELS_DIR) -> list[Path]:
+def missing_model_paths(models_dir: Path | None = None) -> list[Path]:
     return [
         model_path_for(mode, models_dir)
         for mode in supported_denoise_modes()

--- a/src/denoiser/runtime_paths.py
+++ b/src/denoiser/runtime_paths.py
@@ -1,0 +1,17 @@
+"""Runtime resource path helpers for source and PyInstaller builds."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def resource_root() -> Path:
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if bundle_root is not None:
+        return Path(bundle_root)
+    return Path(__file__).resolve().parents[2]
+
+
+def resource_path(relative_path: str | Path) -> Path:
+    return resource_root() / Path(relative_path)

--- a/tests/test_app_entrypoint.py
+++ b/tests/test_app_entrypoint.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def test_pyinstaller_app_script_calls_main_when_executed() -> None:
+    source = Path("src/denoiser/app.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    assert any(
+        isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and ast.unparse(node.test) == "__name__ == '__main__'"
+        for node in tree.body
+    )

--- a/tests/test_app_icon.py
+++ b/tests/test_app_icon.py
@@ -21,3 +21,13 @@ def test_application_icon_loads_in_qt() -> None:
 
     assert not icon.isNull()
     assert icon.availableSizes()
+
+
+def test_application_icon_path_uses_pyinstaller_resource_root(monkeypatch, tmp_path) -> None:
+    bundle_root = tmp_path / "_internal"
+    icon_path = bundle_root / APP_ICON_RELATIVE_PATH
+    icon_path.parent.mkdir(parents=True)
+    icon_path.write_bytes(b"icon")
+    monkeypatch.setattr("sys._MEIPASS", str(bundle_root), raising=False)
+
+    assert application_icon_path() == icon_path

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -11,10 +11,12 @@ from denoiser.engine import (
 )
 from denoiser.models import (
     DenoiseMode,
+    default_models_dir,
     default_denoise_mode,
     missing_model_paths,
     mode_label_for,
     model_tag_for,
+    model_path_for,
     output_folder_for_mode,
     supported_denoise_modes,
 )
@@ -60,6 +62,16 @@ def test_missing_model_paths_reports_missing_required_models(tmp_path) -> None:
         "sfr_hrsem.onnx",
         "sfr_lrsem.onnx",
     }
+
+
+def test_default_model_paths_use_pyinstaller_resource_root(monkeypatch, tmp_path) -> None:
+    bundle_root = tmp_path / "_internal"
+    models_dir = bundle_root / "models"
+    models_dir.mkdir(parents=True)
+    monkeypatch.setattr("sys._MEIPASS", str(bundle_root), raising=False)
+
+    assert default_models_dir() == models_dir
+    assert model_path_for(DenoiseMode.HRSTEM) == models_dir / "sfr_hrstem.onnx"
 
 
 def test_small_images_use_whole_image_inference() -> None:

--- a/tests/test_image_io.py
+++ b/tests/test_image_io.py
@@ -12,6 +12,7 @@ from denoiser.image_io import (
     ImageData,
     ImageFormatError,
     SourceKind,
+    image_dimensions,
     load_image,
     prepare_output_pixels,
     save_restored_image,
@@ -160,3 +161,35 @@ def test_rgb_input_converts_to_grayscale(tmp_path: Path) -> None:
     assert image.pixels.shape == (1, 1)
     assert image.source_dtype == np.dtype(np.uint8)
     assert image.pixels[0, 0] == 76.0
+
+
+def test_load_image_rejects_single_page_stack_like_tiff(tmp_path: Path) -> None:
+    source = tmp_path / "stack_like.tif"
+    tifffile.imwrite(
+        source,
+        np.zeros((2, 3, 4), dtype=np.uint8),
+        metadata={"axes": "ZYX"},
+    )
+
+    try:
+        load_image(source)
+    except ImageFormatError as exc:
+        assert "Stack-like TIFF" in str(exc)
+    else:
+        raise AssertionError("Expected ImageFormatError")
+
+
+def test_image_dimensions_rejects_single_page_stack_like_tiff(tmp_path: Path) -> None:
+    source = tmp_path / "stack_like.tif"
+    tifffile.imwrite(
+        source,
+        np.zeros((2, 3, 4), dtype=np.uint8),
+        metadata={"axes": "ZYX"},
+    )
+
+    try:
+        image_dimensions(source)
+    except ImageFormatError as exc:
+        assert "Stack-like TIFF" in str(exc)
+    else:
+        raise AssertionError("Expected ImageFormatError")


### PR DESCRIPTION
## Summary

- Fix the PyInstaller app entry script so the packaged app calls `main()` when executed.
- Add a shared runtime resource path helper so models and app icon resolve correctly from PyInstaller `_internal` as well as the source tree.
- Update Windows build and release verification docs to match PyInstaller 6 onedir layout.
- Add regression tests for PyInstaller resource lookup, app entrypoint execution, and stack-like TIFF rejection at the image I/O boundary.

## Root cause

`src/denoiser/app.py` was used as the PyInstaller entry script, but it only defined `main()` and did not call it when executed directly. The packaged executable could therefore start and immediately exit. Bundled resources were also documented and partially resolved as if they lived beside the executable, while PyInstaller 6 places data under `_internal` for onedir builds.

## Validation

- `uv run --extra dev pytest` passed: 85 tests.
- Pre-commit hook passed during commit: `prettier --ignore-unknown --write` and `uv run pytest` passed: 85 tests.
- Local ignored artifacts were cleaned from the workspace before publishing; they remain excluded by `.gitignore`.

## Windows follow-up

Final acceptance still requires rebuilding on Windows and launching `dist\Denoiser\Denoiser.exe` from the complete `dist\Denoiser` folder.