### PR TITLE
[codex] Stabilize stack-like TIFF workflow test

### DIFF
--- a/tests/test_single_workflow.py
+++ b/tests/test_single_workflow.py
@@ -48,7 +48,11 @@ def test_restore_single_image_rejects_multi_page_tiff_before_engine(tmp_path: Pa
 
 def test_restore_single_image_rejects_stack_like_tiff_before_engine(tmp_path: Path) -> None:
     source = tmp_path / "stack_like.tif"
-    tifffile.imwrite(source, np.zeros((1, 1, 3, 4), dtype=np.uint8))
+    tifffile.imwrite(
+        source,
+        np.zeros((2, 3, 4), dtype=np.uint8),
+        metadata={"axes": "ZYX"},
+    )
 
     class EngineShouldNotRun:
         def restore(self, pixels, mode):


### PR DESCRIPTION
## Summary

- Make the workflow stack-like TIFF rejection test create an explicit `ZYX` TIFF fixture instead of relying on `tifffile` to infer axes from a raw 4D shape.

## Why

The previous fixture used `np.zeros((1, 1, 3, 4))` without axes metadata. Different `tifffile` versions can infer or serialize that shape differently, so the pytest failure can vary by environment even though the product behavior is still to reject stack-like TIFF input before the engine runs.

## Validation

- Targeted stack-like TIFF tests passed: 3 tests.
- Full test suite passed: 85 tests.
- Pre-commit hook passed during commit: `prettier --ignore-unknown --write` and `uv run pytest` passed: 85 tests.