### PR TITLE
[codex] Fix NiceGUI native launch root

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Denoiser 是一個簡單的 Windows desktop tool，讓 FA engineer 使用
 - Windows build/package guide：`docs/windows-build-and-package.md`
 - Pre-commit hooks：Husky 會執行 lint-staged Prettier 和 `uv run pytest`。
 
+## Local development launch
+
+在 macOS 或開發機上，可以直接用 `uv` 啟動目前的 NiceGUI native-window app：
+
+```bash
+uv sync
+uv run denoiser
+```
+
+這個方式用來做 local development smoke test。正式 end-user release 仍以 Windows
+PyInstaller packaged `Denoiser.exe` 為準。
+
 Initial ADRs 已補上，用來記錄第一版 MVS 的基礎架構決策：
 
 - `docs/adr/0001-use-pyside6-for-windows-desktop-ui.md`

--- a/src/denoiser/nicegui_shell.py
+++ b/src/denoiser/nicegui_shell.py
@@ -639,8 +639,11 @@ def run_nicegui_native_window(*, ui_module: Any | None = None) -> int:
     if ui_module is None:
         from nicegui import ui as ui_module
 
-    render_nicegui_shell(ui_module=ui_module)
+    def render_root() -> None:
+        render_nicegui_shell(ui_module=ui_module)
+
     ui_module.run(
+        root=render_root,
         title="Denoiser",
         native=True,
         window_size=(1280, 820),

--- a/tests/test_nicegui_shell.py
+++ b/tests/test_nicegui_shell.py
@@ -144,6 +144,9 @@ def test_nicegui_shell_runs_as_standard_native_window() -> None:
 
     assert run_nicegui_native_window(ui_module=recording_ui) == 0
 
+    assert recording_ui.run_kwargs is not None
+    root = recording_ui.run_kwargs.pop("root")
+    assert callable(root)
     assert recording_ui.run_kwargs == {
         "title": "Denoiser",
         "native": True,
@@ -153,6 +156,12 @@ def test_nicegui_shell_runs_as_standard_native_window() -> None:
         "reload": False,
         "show": False,
     }
+    assert recording_ui.labels == []
+
+    root()
+
+    assert "Denoiser" in recording_ui.labels
+    assert "Single image inspection" in recording_ui.labels
 
 
 def test_denoiser_main_launches_nicegui_native_shell(monkeypatch) -> None:

--- a/tests/test_windows_build_script.py
+++ b/tests/test_windows_build_script.py
@@ -54,6 +54,14 @@ def test_windows_build_packages_nicegui_app_and_bundled_resources() -> None:
         assert option in script
 
 
+def test_windows_packaged_entrypoint_uses_nicegui_root_function() -> None:
+    script = Path("scripts/build_windows.ps1").read_text(encoding="utf-8")
+    shell_source = Path("src/denoiser/nicegui_shell.py").read_text(encoding="utf-8")
+
+    assert "src\\denoiser\\app.py" in script
+    assert "root=render_root" in shell_source
+
+
 def test_dm3_pyinstaller_probe_covers_required_import_chain() -> None:
     assert REQUIRED_IMPORTS == [
         "rsciio.digitalmicrograph",


### PR DESCRIPTION
## Summary

Fix the NiceGUI native-window launch path by passing an explicit `root` function to `ui.run`.

## Root cause

NiceGUI 3.11 enters script mode when UI is rendered before `ui.run()` without an explicit root function. In that mode, the root request can re-execute the console script entrypoint, which produced `run_script()` / `SystemExit: 0` / ASGI exception output during local launch.

## Impact

`uv run denoiser` now starts without the script-mode re-exec error. The same fix applies to the Windows PyInstaller entrypoint because the Windows build packages `src\denoiser\app.py`, which calls the same NiceGUI shell startup function.

## Validation

- `uv run pytest` passed with 93 tests.
- Local launch smoke check no longer showed `run_script`, `SystemExit: 0`, or ASGI exception output.

## Notes

Actual Windows `Denoiser.exe` release verification still needs to be run on a Windows machine.